### PR TITLE
Read feed from /radio1 instead of /programmi/gr1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-grr-feed",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "server.js",
   "scripts": {
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "express": "^4.16.2",
-    "moment-timezone": "^0.5.14",
     "newrelic": "^2.6.0",
     "node-fetch": "^1.7.3"
   },


### PR DESCRIPTION
This change fixes an issue with the audio returned by `/programmi/gr1`
not being available outside of Italy.

I manually tested the server:

```
$ curl http://localhost:8080 2>/dev/null | jq .
{
  "uid": "ContentItem-5bc5f219-26df-41e8-b335-fca4ba72647b",
  "updateDate": "2021-07-28T02:00:00.000Z",
  "titleText": "Ultimo GR1",
  "mainText": "",
  "streamUrl": "https://mediapolisvod.rai.it/relinker/relinkerServlet.htm?cont=RpPpPlussrzxPsmqmkeMDBAMRv7OgeeqqEEqualeeqqEEqual",
  "redirectionUrl": "https://grr.rai.it"
}
```

Fixes #4